### PR TITLE
Now assume Throwable as baseline type for exception handler.

### DIFF
--- a/src/soot/jimple/toolkits/typing/fast/AugEvalFunction.java
+++ b/src/soot/jimple/toolkits/typing/fast/AugEvalFunction.java
@@ -151,10 +151,14 @@ public class AugEvalFunction implements IEvalFunction
 					r = t;
 				else if (t.getSootClass().isPhantom())
 					r = Scene.v().getRefType("java.lang.Throwable");
-				else
-					/* In theory, we could have multiple exception types 
+				else {
+					/* In theory, we could have multiple exception types
 					pointing here. The JLS requires the exception parameter be a *subclass* of Throwable, so we do not need to worry about multiple inheritance. */
 					r = BytecodeHierarchy.lcsc(r, t);
+					if (r == null) {
+						r = Scene.v().getRefType("java.lang.Throwable");
+					}
+				}
 			}
 			
 			if ( r == null )


### PR DESCRIPTION
For exception handler like: catch (ExceptionType1 | ExceptionType2 e){}
the lowest common super class cannot always be found due to missing
information caused by phantom classes. In this case we assume Throwable
as safe base line.