### PR TITLE
Use the information from the constant pool of the Jars to fix up the

### DIFF
--- a/src/soot/asm/AsmMethodSource.java
+++ b/src/soot/asm/AsmMethodSource.java
@@ -1454,6 +1454,9 @@ final class AsmMethodSource implements MethodSource {
 		StackFrame frame = getFrame(insn);
 		Operand opr = dword ? popDual() : pop();
 		Local local = getLocal(insn.var);
+		if (opr.stack != null) {
+			opr.stack.setName(local.getName());
+		}
 		if (!units.containsKey(insn)) {
 			DefinitionStmt as = Jimple.v().newAssignStmt(local, opr.stackOrValue());
 			opr.addBox(as.getRightOpBox());


### PR DESCRIPTION
names of stack variables during jimple generation.