### PR TITLE
Make results reproducable.

### DIFF
--- a/src/soot/asm/AsmMethodSource.java
+++ b/src/soot/asm/AsmMethodSource.java
@@ -1588,7 +1588,13 @@ final class AsmMethodSource implements MethodSource {
 	
 	private void convert() {
 		ArrayDeque<Edge> worklist = new ArrayDeque<Edge>();
-		for (LabelNode ln : trapHandlers.keySet()) {
+
+		List<LabelNode> traps = new ArrayList<>();
+		for (TryCatchBlockNode node: tryCatchBlocks) {
+			traps.add(node.handler);
+		}
+
+		for (LabelNode ln : traps) {
 			if (checkInlineExceptionHandler(ln))
 				handleInlineExceptionHandler(ln, worklist);
 			else
@@ -1740,6 +1746,7 @@ final class AsmMethodSource implements MethodSource {
 			else
 				iloc++;
 		}
+
 		for (Local l : locals.values()){
 			jbl.add(l);
 		}
@@ -1953,7 +1960,7 @@ final class AsmMethodSource implements MethodSource {
 		emitLocals();
 		emitTraps();
 		emitUnits();
-		
+
 		/* clean up */
 		locals = null;
 		labels = null;

--- a/src/soot/jimple/toolkits/typing/fast/TypeResolver.java
+++ b/src/soot/jimple/toolkits/typing/fast/TypeResolver.java
@@ -241,7 +241,7 @@ public class TypeResolver
 					must by typed with concrete Jimple types, and never [0..1],
 					[0..127] or [0..32767]. */
 					vold = Jimple.v().newLocal("tmp", t);
-					vold.setName("tmp$" + System.identityHashCode(vold));
+					vold.setName("$tmp" + System.identityHashCode(vold));
 					this.tg.set(vold, t);
 					this.jb.getLocals().add(vold);
 					Unit u = Util.findFirstNonIdentityUnit(jb, stmt);
@@ -252,7 +252,7 @@ public class TypeResolver
 					vold = (Local)op;
 				
 				Local vnew = Jimple.v().newLocal("tmp", useType);
-				vnew.setName("tmp$" + System.identityHashCode(vnew));
+				vnew.setName("$tmp" + System.identityHashCode(vnew));
 				this.tg.set(vnew, useType);
 				this.jb.getLocals().add(vnew);
 				Unit u = Util.findFirstNonIdentityUnit(jb, stmt);
@@ -603,7 +603,7 @@ public class TypeResolver
 								{
 									Local newlocal = Jimple.v().newLocal(
 										"tmp", null);
-									newlocal.setName("tmp$" + System.identityHashCode(newlocal));
+									newlocal.setName("$tmp" + System.identityHashCode(newlocal));
 									this.jb.getLocals().add(newlocal);
 									
 									special.setBase(newlocal);


### PR DESCRIPTION
For the TypeResolver some local names needed to be prefixed with $
to have same handled by the LocalNAmeStandardizer class which replaces
the random names through up counting numbers.

For AsmMethodSource the traps are now added to the initial convert
worklist in a deterministic manner which results in consitent stack
variable naming.