### PR TITLE
Rewrote getIdentityRef... to use worklist.

### DIFF
--- a/src/soot/asm/AsmMethodSource.java
+++ b/src/soot/asm/AsmMethodSource.java
@@ -1863,12 +1863,26 @@ final class AsmMethodSource implements MethodSource {
 	}
 
 	private IdentityStmt getIdentityRefFromContrainer(UnitContainer u) {
-		for (Unit uu : ((UnitContainer) u).units) {
-			if (uu instanceof IdentityStmt) {
-				return (IdentityStmt) uu;
+	  	ArrayList<UnitContainer> worklist = new ArrayList<>();
+
+	  	worklist.add(u);
+
+	  	while (!worklist.isEmpty()) {
+	  		UnitContainer next = worklist.remove(worklist.size() - 1);
+
+	  		Unit children[] = next.units;
+	  		if (children[0] instanceof IdentityStmt) {
+	  			return (IdentityStmt) children[0];
+			} else {
+	  			List<UnitContainer> nestedContainers = new ArrayList<>();
+	  			for (Unit child: children) {
+	  				if (child instanceof UnitContainer) {
+						nestedContainers.add((UnitContainer) child);
+					}
+				}
+				Collections.reverse(nestedContainers);
+	  			worklist.addAll(nestedContainers);
 			}
-			else if (uu instanceof UnitContainer)
-				return getIdentityRefFromContrainer((UnitContainer) uu);
 		}
 		return null;
 	}


### PR DESCRIPTION
This way we avoid running out of stack space for deeply nested
constructs.

Proposed fix for the StackOverFlow exception in:
https://github.com/ShiftLeftSecurity/product/issues/860

Since i do not have the customer jar to test, this change might lead to an infinte loop if the SOOT data structure is
for whatever reason cyclic.