### PR TITLE
Disable copy propagation.

### DIFF
--- a/src/soot/PackManager.java
+++ b/src/soot/PackManager.java
@@ -978,7 +978,7 @@ public class PackManager {
             if (produceJimple) {
                 Body body = m.retrieveActiveBody();
                 //Change
-                CopyPropagator.v().transform(body);
+                //CopyPropagator.v().transform(body);
                 ConditionalBranchFolder.v().transform(body);
                 UnreachableCodeEliminator.v().transform(body);
                 DeadAssignmentEliminator.v().transform(body);


### PR DESCRIPTION
This has two reasons:
- For lambda/closure literals assigned to local variables are propagated
  to the dynamic call instruction of the lambda meta factory. This than
  gives the impression that a literal was captured into a closure which
  does not make sense and hides the information about which local was
  actually captured.
- As a consequence of copy propagation SOOT will remove local variables
  which are not used anymore after propagation, which harms our
  sensitive data matching.