### PR TITLE
Two changes and a version bump.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>soot-shiftleft</artifactId>
   
   <name>Soot</name>
-  <version>0.2.2</version>
+  <version>0.2.3-SNAPSHOT</version>
   <description>A Java Optimization Framework</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>soot-shiftleft</artifactId>
   
   <name>Soot</name>
-  <version>0.2.2-SNAPSHOT</version>
+  <version>0.2.2</version>
   <description>A Java Optimization Framework</description>
 
   <properties>

--- a/src/soot/PackManager.java
+++ b/src/soot/PackManager.java
@@ -978,7 +978,8 @@ public class PackManager {
             if (produceJimple) {
                 Body body = m.retrieveActiveBody();
                 //Change
-                CopyPropagator.v().transform(body);
+                Map<String, String> options = PhaseOptions.v().getPhaseOptions( "jb.cp" );
+                CopyPropagator.v().transform(body, "jb.cp", options);
                 ConditionalBranchFolder.v().transform(body);
                 UnreachableCodeEliminator.v().transform(body);
                 DeadAssignmentEliminator.v().transform(body);

--- a/src/soot/jimple/toolkits/typing/fast/TypeResolver.java
+++ b/src/soot/jimple/toolkits/typing/fast/TypeResolver.java
@@ -156,6 +156,16 @@ public class TypeResolver
 		
 		int[] castCount = new int[1];
 		Typing tg = this.minCasts(sigma, bh, castCount);
+		/*
+		ML: We want to avoid creating useless temporary variables
+			in the split_new method by spliting up the initial local
+			variable assignments. This creates overhead and more
+			importantly creates alias to the same object which
+			complicates later analysis.
+			This is because the way in which the split is implemented,
+			the <init> method is "executed" on the new introduced
+			tmp local variable, whereas following code works on the
+			original local.
 		if ( castCount[0] != 0 )
 		{
 			this.split_new();
@@ -163,6 +173,7 @@ public class TypeResolver
 				new Typing(this.jb.getLocals()), ef, bh);
 			tg = this.minCasts(sigma, bh, castCount);
 		}
+		*/
 		this.insertCasts(tg, bh, false);
 		
 		for ( Local v : this.jb.getLocals() )


### PR DESCRIPTION
Run CopyPropagator with global options.
This has two reasons:
- For lambda/closure literals assigned to local variables are propagated
  to the dynamic call instruction of the lambda meta factory. This than
  gives the impression that a literal was captured into a closure which
  does not make sense and hides the information about which local was
  actually captured.
- As a consequence of copy propagation SOOT will remove local variables
  which are not used anymore after propagation, which harms our
  sensitive data matching.


Do not split new assignments.
We want to avoid creating useless temporary variables in the split_new
method by spliting up the initial local variable assignments. This creates
overhead and more importantly creates alias to the same object which
complicates later analysis. This is because the way in which the split is
implemented, the <init> method is "executed" on the new introduced tmp
local variable, whereas following code works on the original local.