### PR TITLE
Fix local variable mixup in case of no debug information.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>soot-shiftleft</artifactId>
   
   <name>Soot</name>
-  <version>0.2.5-SNAPSHOT</version>
+  <version>0.2.5</version>
   <description>A Java Optimization Framework</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>soot-shiftleft</artifactId>
   
   <name>Soot</name>
-  <version>0.2.5</version>
+  <version>0.2.6-SNAPSHOT</version>
   <description>A Java Optimization Framework</description>
 
   <properties>

--- a/src/soot/JimpleBodyPack.java
+++ b/src/soot/JimpleBodyPack.java
@@ -59,12 +59,13 @@ public class JimpleBodyPack extends BodyPack
         // locals for not creating disconnected islands of useless assignments
         // that afterwards mess up type assignment.
         PackManager.v().getTransform( "jb.uce" ).apply( b );
-		
+
+        PackManager.v().getTransform( "jb.a" ).apply( b );
+
         PackManager.v().getTransform( "jb.ls" ).apply( b );
 
         if(Options.v().time()) Timers.v().splitTimer.end();
 
-        PackManager.v().getTransform( "jb.a" ).apply( b );
         PackManager.v().getTransform( "jb.ule" ).apply( b );
 
         if(Options.v().time()) Timers.v().assignTimer.start();
@@ -78,7 +79,7 @@ public class JimpleBodyPack extends BodyPack
             PackManager.v().getTransform( "jb.ulp" ).apply( b );
         }
         PackManager.v().getTransform( "jb.lns" ).apply( b );		// LocalNameStandardizer
-        PackManager.v().getTransform( "jb.cp" ).apply( b );			// CopyPropagator
+        //PackManager.v().getTransform( "jb.cp" ).apply( b );			// CopyPropagator
         PackManager.v().getTransform( "jb.dae" ).apply( b );		// DeadAssignmentElimintaor
         PackManager.v().getTransform( "jb.cp-ule" ).apply( b );		// UnusedLocalEliminator
         PackManager.v().getTransform( "jb.lp" ).apply( b );			// LocalPacker

--- a/src/soot/PackManager.java
+++ b/src/soot/PackManager.java
@@ -978,8 +978,8 @@ public class PackManager {
             if (produceJimple) {
                 Body body = m.retrieveActiveBody();
                 //Change
-                Map<String, String> options = PhaseOptions.v().getPhaseOptions( "jb.cp" );
-                CopyPropagator.v().transform(body, "jb.cp", options);
+                //Map<String, String> options = PhaseOptions.v().getPhaseOptions( "jb.cp" );
+                //CopyPropagator.v().transform(body, "jb.cp", options);
                 ConditionalBranchFolder.v().transform(body);
                 UnreachableCodeEliminator.v().transform(body);
                 DeadAssignmentEliminator.v().transform(body);


### PR DESCRIPTION
If a local variable was pushed to stack and than reassigned, the local
variable representing the stack value got assigned the same name as the
original local which is invalid. We solve this by running the Aggregator
before the LocalSplitter
(previously the Agrregator did not work on splitted locals because it did
not handle the "#" suffix like other transforms do) and not using the
CopyPropagator at all. The CopyPropagator seems to be a less elaborate
aggregator and is now not need anymore since the aggregator is working
correctly.