### PR TITLE
Fix crash which resulted from NullType for local array.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>soot-shiftleft</artifactId>
   
   <name>Soot</name>
-  <version>0.2.6</version>
+  <version>0.2.7-SNAPSHOT</version>
   <description>A Java Optimization Framework</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>soot-shiftleft</artifactId>
   
   <name>Soot</name>
-  <version>0.2.6-SNAPSHOT</version>
+  <version>0.2.6</version>
   <description>A Java Optimization Framework</description>
 
   <properties>

--- a/src/soot/jimple/toolkits/typing/fast/TypeResolver.java
+++ b/src/soot/jimple/toolkits/typing/fast/TypeResolver.java
@@ -35,11 +35,13 @@ import soot.CharType;
 import soot.IntType;
 import soot.IntegerType;
 import soot.Local;
+import soot.NullType;
 import soot.PatchingChain;
 import soot.RefType;
 import soot.ShortType;
 import soot.Type;
 import soot.Unit;
+import soot.UnknownType;
 import soot.Value;
 import soot.jimple.ArrayRef;
 import soot.jimple.AssignStmt;
@@ -499,12 +501,22 @@ public class TypeResolver
 						of assignments where there is supertyping between array
 						types, which is only for arrays of reference types and
 						multidimensional arrays. */
-						if ( !(t_ instanceof RefType
-							|| t_ instanceof ArrayType) )
+						/* ML: But we if we know nothing about the left hand side
+						we want to take the information of the right hand side.
+						The only scenario where we encountered this is so far is:
+						int[] array = null;
+						if (array != null) {
+							array[someIndex] = someValue;
+						}
+						As you see this code does not really make sense but we
+						still dont want to crash.
+						 */
+						if (!( t_ instanceof RefType || t_ instanceof ArrayType
+							|| told instanceof NullType || told instanceof UnknownType))
 						{
 							continue;
 						}
-							
+
 						t_ = t_.makeArrayType();
 					}
 					


### PR DESCRIPTION
Simplified version of the problematic code:
int[] array = null;
if (array != null) {
	array[someIndex] = someValue;
}

For not very practial code above, the type resolver now also deducts
the type of array from the assignment of someValue into the array
and not just during the assignement of array itself.