### PR TITLE
Workaround CFG build for body-less methods

### DIFF
--- a/src/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
+++ b/src/soot/jimple/toolkits/callgraph/OnFlyCallGraphBuilder.java
@@ -1052,6 +1052,17 @@ public final class OnFlyCallGraphBuilder
         if( m.isNative() || m.isPhantom() ) {
             return;
         }
+
+        // Workaround for weird cases, when there is no body attached to the method, since
+        // the declaring class is an interface. This excludes the special case of static initializers,
+        // which we still want to process.
+        SootClass clazz = m.getDeclaringClass();
+        if (!m.isStaticInitializer() && m.isAbstract() && clazz != null && clazz.isInterface()) {
+            // Won't find the body anyway
+            System.out.println("Dropping for " + clazz.getName() + " and method " + m.getName());
+            return;
+        }
+
         Body b = m.retrieveActiveBody();
         getImplicitTargets( m );
         findReceivers(m, b);


### PR DESCRIPTION
For some reason Soot is attempting to build a CFG for (abstract) methods
that have no body attached, since they are declared in the interfaces.
Looks like a rather werid corner case that was not taken into account.

Rather than processing such methods, we just skip them, which does not
appear to affect the overall construction in usual circumstances.