### PR TITLE
Fix crash on NullConstant as array base.

### DIFF
--- a/src/soot/jimple/internal/JArrayRef.java
+++ b/src/soot/jimple/internal/JArrayRef.java
@@ -44,7 +44,7 @@ public class JArrayRef implements ArrayRef, ConvertToBaf
 
     public JArrayRef(Value base, Value index)
     {
-        this(Jimple.v().newLocalBox(base),
+        this(base instanceof Immediate ? Jimple.v().newImmediateBox(base): Jimple.v().newLocalBox(base),
              Jimple.v().newImmediateBox(index));
     }
 

--- a/src/soot/jimple/toolkits/typing/fast/AugEvalFunction.java
+++ b/src/soot/jimple/toolkits/typing/fast/AugEvalFunction.java
@@ -170,22 +170,25 @@ public class AugEvalFunction implements IEvalFunction
 		}
 		else if ( expr instanceof ArrayRef )
 		{
-			Local av = (Local)((ArrayRef)expr).getBase();
-			Type at = tg.get(av);
-			
-			if ( at instanceof ArrayType )
-				return ((ArrayType)at).getElementType();
-			else if ( at instanceof RefType ) {
-				RefType ref = (RefType) at;
-				if (ref.getSootClass().getName().equals("java.lang.Object")
-						|| ref.getSootClass().getName().equals("java.io.Serializable")
-						|| ref.getSootClass().getName().equals("java.lang.Cloneable"))
-					return ref;
-				else
+			Value av = ((ArrayRef)expr).getBase();
+			if (av instanceof Local) {
+				Type at = tg.get((Local)av);
+
+				if (at instanceof ArrayType)
+					return ((ArrayType) at).getElementType();
+				else if (at instanceof RefType) {
+					RefType ref = (RefType) at;
+					if (ref.getSootClass().getName().equals("java.lang.Object")
+							|| ref.getSootClass().getName().equals("java.io.Serializable")
+							|| ref.getSootClass().getName().equals("java.lang.Cloneable"))
+						return ref;
+					else
+						return BottomType.v();
+				} else
 					return BottomType.v();
+			} else {
+				return BooleanType.v();
 			}
-			else
-				return BottomType.v();
 		}
 		else if ( expr instanceof NewArrayExpr )
 			return ((NewArrayExpr)expr).getBaseType().makeArrayType();

--- a/src/soot/jimple/toolkits/typing/fast/TypeResolver.java
+++ b/src/soot/jimple/toolkits/typing/fast/TypeResolver.java
@@ -130,8 +130,12 @@ public class TypeResolver
 				if ( op instanceof Local )
 					this.addDepend((Local)op, assignmentIdx);
 			}
-			else if ( rhs instanceof ArrayRef )
-				this.addDepend((Local)((ArrayRef)rhs).getBase(), assignmentIdx);
+			else if ( rhs instanceof ArrayRef ) {
+				Value base = ((ArrayRef)rhs).getBase();
+				if (base instanceof Local) {
+					this.addDepend((Local)base, assignmentIdx);
+				}
+			}
 		}
 	}
 	


### PR DESCRIPTION
This is the fix for https://github.com/ShiftLeftSecurity/product/issues/3392.

While having a NullConstant as base for an array access is not very
useful, we now do not crash anymore upon handling it.