### PR TITLE
Make SOOT not crash on JVMs newer than version 8.

### DIFF
--- a/generated/jastadd/soot/JastAddJ/Program.java
+++ b/generated/jastadd/soot/JastAddJ/Program.java
@@ -329,24 +329,18 @@ public class Program extends ASTNode<ASTNode> implements Cloneable {
       ArrayList classPaths = new ArrayList();
       ArrayList sourcePaths = new ArrayList();
       
-      String[] bootclasspaths;
-      if(options().hasValueForOption("-bootclasspath"))
-        bootclasspaths = options().getValueForOption("-bootclasspath").split(File.pathSeparator);
-      else
-        bootclasspaths = System.getProperty("sun.boot.class.path").split(File.pathSeparator);
-      for(int i = 0; i < bootclasspaths.length; i++) {
-        classPaths.add(bootclasspaths[i]);
-        //System.err.println("Adding classpath " + bootclasspaths[i]);
+      if(options().hasValueForOption("-bootclasspath")) {
+        String[] bootclasspaths = options().getValueForOption("-bootclasspath").split(File.pathSeparator);
+        for(int i = 0; i < bootclasspaths.length; i++) {
+          classPaths.add(bootclasspaths[i]);
+        }
       }
-      
-      String[] extdirs;
-      if(options().hasValueForOption("-extdirs"))
-        extdirs = options().getValueForOption("-extdirs").split(File.pathSeparator);
-      else
-        extdirs = System.getProperty("java.ext.dirs").split(File.pathSeparator);
-      for(int i = 0; i < extdirs.length; i++) {
-        classPaths.add(extdirs[i]);
-        //System.err.println("Adding classpath " + extdirs[i]);
+
+      if(options().hasValueForOption("-extdirs")) {
+        String[] extdirs = options().getValueForOption("-extdirs").split(File.pathSeparator);
+        for(int i = 0; i < extdirs.length; i++) {
+          classPaths.add(extdirs[i]);
+        }
       }
 
       String[] userClasses = null;

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>soot-shiftleft</artifactId>
   
   <name>Soot</name>
-  <version>0.2.34-SNAPSHOT</version>
+  <version>0.2.34</version>
   <description>A Java Optimization Framework</description>
 
   <properties>


### PR DESCRIPTION
Stop trying to access system properties "sun.boo.class.path" and
"java.ext.dirs" which got removed from those never versions. For our
usecase those classes are not need since we anyway model library methods
via policies.