### PR TITLE
Revert call graph disabling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>soot-shiftleft</artifactId>
   
   <name>Soot</name>
-  <version>0.2.37</version>
+  <version>0.2.36</version>
   <description>A Java Optimization Framework</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>soot-shiftleft</artifactId>
   
   <name>Soot</name>
-  <version>0.2.36</version>
+  <version>0.2.38</version>
   <description>A Java Optimization Framework</description>
 
   <properties>

--- a/src/soot/PackManager.java
+++ b/src/soot/PackManager.java
@@ -194,7 +194,7 @@ public class PackManager {
         // Call graph pack
         addPack(p = new CallGraphPack("cg"));
         {
-            //p.add(new Transform("cg.cha", CHATransformer.v()));
+            p.add(new Transform("cg.cha", CHATransformer.v()));
             p.add(new Transform("cg.spark", SparkTransformer.v()));
             p.add(new Transform("cg.paddle", PaddleHook.v()));
         }

--- a/src/soot/RadioScenePack.java
+++ b/src/soot/RadioScenePack.java
@@ -40,11 +40,11 @@ public class RadioScenePack extends ScenePack
             if( !PhaseOptions.getBoolean( opts, "enabled" ) ) continue;
             enableds.add( t );
         }
-        //if( enableds.size() == 0 ) {
-        //    G.v().out.println( "Exactly one phase in the pack "+getPhaseName()+
-        //            " must be enabled. Currently, none of them are." );
-        //    throw new CompilationDeathException( CompilationDeathException.COMPILATION_ABORTED );
-        //}
+        if( enableds.size() == 0 ) {
+            G.v().out.println( "Exactly one phase in the pack "+getPhaseName()+
+                    " must be enabled. Currently, none of them are." );
+            throw new CompilationDeathException( CompilationDeathException.COMPILATION_ABORTED );
+        }
         if( enableds.size() > 1 ) {
             G.v().out.println( "Only one phase in the pack "+getPhaseName()+
                     " may be enabled. The following are enabled currently: " );


### PR DESCRIPTION
Call graph analysis required. Sadly not for the actual analysis result but for its
side effects of creating and initializing global state in a single threaded context.
Not running this analysis and thus not forcing the initialization in a single threaded
context leads to the initialization being done from our multi threaded CPG translation
context which leads to all kinds of race conditions since the SOOT code is not thread
safe.
